### PR TITLE
Add difference percentages to CompareResult

### DIFF
--- a/src/main/java/de/redsix/pdfcompare/CompareResult.java
+++ b/src/main/java/de/redsix/pdfcompare/CompareResult.java
@@ -2,6 +2,7 @@ package de.redsix.pdfcompare;
 
 import java.io.OutputStream;
 import java.util.Collection;
+import java.util.Map;
 
 public interface CompareResult {
 
@@ -99,4 +100,11 @@ public interface CompareResult {
      * @return collection of page numbers, that have a difference
      */
     Collection<Integer> getPagesWithDifferences();
+
+    /**
+     * Gives a map of the difference percentages per page.
+     * 
+     * @return difference percentages mapped to the page index.
+     */
+    Map<Integer, Double> getPageDiffsInPercent();
 }

--- a/src/main/java/de/redsix/pdfcompare/CompareResultImpl.java
+++ b/src/main/java/de/redsix/pdfcompare/CompareResultImpl.java
@@ -47,6 +47,7 @@ public class CompareResultImpl implements ResultCollector, CompareResult {
     private boolean expectedOnly;
     private boolean actualOnly;
     private final Collection<PageArea> diffAreas = new ArrayList<>();
+    private final Map<Integer, Double> diffPercentages = new TreeMap<>();
     private int pages = 0;
 
     @Override
@@ -131,10 +132,14 @@ public class CompareResultImpl implements ResultCollector, CompareResult {
             isEqual = false;
             diffAreas.add(diffCalculator.getDiffArea());
             diffImages.put(pageIndex, diffImage);
+            diffPercentages.put(pageIndex, diffCalculator.getDifferenceInPercent());
             pages++;
-        } else if (environment.addEqualPagesToResult()) {
-            diffImages.put(pageIndex, diffImage);
-            pages++;
+        } else {
+            diffPercentages.put(pageIndex, 0.0);
+            if (environment.addEqualPagesToResult()) {
+                diffImages.put(pageIndex, diffImage);
+                pages++;
+            }
         }
     }
 
@@ -191,6 +196,11 @@ public class CompareResultImpl implements ResultCollector, CompareResult {
     @Override
     public Collection<Integer> getPagesWithDifferences() {
         return diffAreas.stream().map(a -> a.page).collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<Integer, Double> getPageDiffsInPercent() {
+        return diffPercentages;
     }
 
     public void expectedOnly() {

--- a/src/main/java/de/redsix/pdfcompare/CompareResultImpl.java
+++ b/src/main/java/de/redsix/pdfcompare/CompareResultImpl.java
@@ -128,18 +128,15 @@ public class CompareResultImpl implements ResultCollector, CompareResult {
         Objects.requireNonNull(actualImage, "actualImage is null");
         Objects.requireNonNull(diffImage, "diffImage is null");
         this.hasDifferenceInExclusion |= diffCalculator.differencesFoundInExclusion();
+        diffPercentages.put(pageIndex, diffCalculator.getDifferenceInPercent());
         if (diffCalculator.differencesFound()) {
             isEqual = false;
             diffAreas.add(diffCalculator.getDiffArea());
             diffImages.put(pageIndex, diffImage);
-            diffPercentages.put(pageIndex, diffCalculator.getDifferenceInPercent());
             pages++;
-        } else {
-            diffPercentages.put(pageIndex, 0.0);
-            if (environment.addEqualPagesToResult()) {
-                diffImages.put(pageIndex, diffImage);
-                pages++;
-            }
+        } else if (environment.addEqualPagesToResult()) {
+            diffImages.put(pageIndex, diffImage);
+            pages++;
         }
     }
 

--- a/src/main/java/de/redsix/pdfcompare/PageDiffCalculator.java
+++ b/src/main/java/de/redsix/pdfcompare/PageDiffCalculator.java
@@ -50,6 +50,14 @@ public class PageDiffCalculator {
         return diffsFoundInExclusion > 0;
     }
 
+    public double getDifferenceInPercent() {
+        if (totalPixels == 0) {
+            return diffsFound > 0 ? 100.0 : 0.0;
+        } else {
+            return (double)diffsFound / (double)totalPixels * 100.0;
+        }
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/src/test/java/de/redsix/pdfcompare/CompareResultImplTest.java
+++ b/src/test/java/de/redsix/pdfcompare/CompareResultImplTest.java
@@ -1,5 +1,6 @@
 package de.redsix.pdfcompare;
 
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -7,6 +8,7 @@ import de.redsix.pdfcompare.env.SimpleEnvironment;
 import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
+import java.util.Map;
 
 class CompareResultImplTest {
 
@@ -34,5 +36,23 @@ class CompareResultImplTest {
         assertThat(compareResult.hasImages(), is(true));
         assertThat(compareResult.getNumberOfPages(), is(1));
         assertThat(compareResult.diffImages.size(), is(1));
+    }
+
+    @Test
+    public void mapsDiffPercentagesCorrectly() {
+        CompareResultImpl compareResult = new CompareResultImpl();
+        compareResult.setEnvironment(new SimpleEnvironment());
+        ImageWithDimension image = new ImageWithDimension(new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_BINARY), 0.0f, 0.0f);
+
+        PageDiffCalculator pageWithDiff = new PageDiffCalculator(5, 0);
+        pageWithDiff.diffFound();
+        PageDiffCalculator pageWithoutDiff = new PageDiffCalculator(10, 0);
+
+        compareResult.addPage(pageWithDiff, 1, image, image, image);
+        compareResult.addPage(pageWithoutDiff, 2, image, image, image);
+
+        Map<Integer, Double> result = compareResult.getPageDiffsInPercent();
+        assertThat(result, hasEntry(1, 20.0));
+        assertThat(result, hasEntry(2, 0.0));
     }
 }

--- a/src/test/java/de/redsix/pdfcompare/PageDiffCalculatorTest.java
+++ b/src/test/java/de/redsix/pdfcompare/PageDiffCalculatorTest.java
@@ -1,5 +1,6 @@
 package de.redsix.pdfcompare;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -61,5 +62,32 @@ class PageDiffCalculatorTest {
         diffCalculator.diffFound();
         diffCalculator.diffFound();
         assertTrue(diffCalculator.differencesFound());
+    }
+
+    @Test
+    public void zeroTotalPixelsWithDiffFoundReportsHundredPercentDifference() {
+        final PageDiffCalculator diffCalculator = new PageDiffCalculator(0, 0);
+        diffCalculator.diffFound();
+        assertEquals(100.0, diffCalculator.getDifferenceInPercent());
+    }
+
+    @Test
+    public void zeroTotalPixelsWithNoDiffFoundReportsZeroPercentDifference() {
+        final PageDiffCalculator diffCalculator = new PageDiffCalculator(0, 0);
+        assertEquals(0.0, diffCalculator.getDifferenceInPercent());
+    }
+
+    @Test
+    public void diffsFoundReportsCorrectPercentage() {
+        final PageDiffCalculator diffCalculator = new PageDiffCalculator(10, 0);
+        diffCalculator.diffFound();
+        diffCalculator.diffFound();
+        assertEquals(20.0, diffCalculator.getDifferenceInPercent());
+    }
+
+    @Test
+    public void noDiffsFoundReportsCorrectPercentage() {
+        final PageDiffCalculator diffCalculator = new PageDiffCalculator(6, 0);
+        assertEquals(0.0, diffCalculator.getDifferenceInPercent());
     }
 }


### PR DESCRIPTION
Saw #79 open for a while and decided to give a solution a try.

This PR will add `Map<Integer, Double> getPageDiffsInPercent()` to the `CompareResult` interface, exposing a collection of difference percentages mapped to their respective page index.

There is a special case in `PageDiffCalculator` where `totalPixels` can be zero. In this case I decided to return 0% when there are no differences, and 100% when there are differences, since there is nothing to calculate the percentage with. I'm not sure if this is the correct way to go, so please let me know if you have different ideas.