### PR TITLE
Fix expected/actual colors

### DIFF
--- a/src/main/java/de/redsix/pdfcompare/env/ConfigFileEnvironment.java
+++ b/src/main/java/de/redsix/pdfcompare/env/ConfigFileEnvironment.java
@@ -108,7 +108,7 @@ public class ConfigFileEnvironment implements Environment {
         if (config.hasPath("expectedColor")) {
             return Color.decode("#" + config.getString("expectedColor"));
         }
-        return new Color(0, 180, 0);
+        return new Color(210, 0, 0);
     }
 
     @Override
@@ -116,7 +116,7 @@ public class ConfigFileEnvironment implements Environment {
         if (config.hasPath("actualColor")) {
             return Color.decode("#" + config.getString("actualColor"));
         }
-        return new Color(210, 0, 0);
+        return new Color(0, 180, 0);
     }
 
     @Override


### PR DESCRIPTION
According to README.md, by default expectedColor=D20000, and actualColor=00B400. But in the code, it is actually messed up.

The only little problem I see with this fix - it will be unconvenient for users who, like me, didn't notice this and use `PdfComparator(actual, expected)` (inverted parameter order gives "normal" colors).