### PR TITLE
Upgrade pdfbox dependency to 3.0.0-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.25</version>
+            <version>3.0.0-RC1</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/src/main/java/de/redsix/pdfcompare/PdfComparator.java
+++ b/src/main/java/de/redsix/pdfcompare/PdfComparator.java
@@ -21,6 +21,7 @@ import de.redsix.pdfcompare.env.ConfigFileEnvironment;
 import de.redsix.pdfcompare.env.DefaultEnvironment;
 import de.redsix.pdfcompare.env.Environment;
 import de.redsix.pdfcompare.env.SimpleEnvironment;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -388,10 +389,10 @@ public class PdfComparator<T extends CompareResultImpl> {
             buildEnvironment();
             try (final InputStream expectedStream = expectedStreamSupplier.get()) {
                 try (final InputStream actualStream = actualStreamSupplier.get()) {
-                    try (PDDocument expectedDocument = PDDocument
-                            .load(expectedStream, expectedPassword, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
-                        try (PDDocument actualDocument = PDDocument
-                                .load(actualStream, actualPassword, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
+                    try (PDDocument expectedDocument = Loader
+                            .loadPDF(expectedStream, expectedPassword, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
+                        try (PDDocument actualDocument = Loader
+                                .loadPDF(actualStream, actualPassword, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
                             compare(expectedDocument, actualDocument);
                         }
                     }
@@ -497,7 +498,7 @@ public class PdfComparator<T extends CompareResultImpl> {
     }
 
     private void addSingleDocumentToResult(InputStream expectedPdfIS, int markerColor) throws IOException {
-        try (PDDocument expectedDocument = PDDocument.load(expectedPdfIS)) {
+        try (PDDocument expectedDocument = Loader.loadPDF(expectedPdfIS)) {
             PDFRenderer expectedPdfRenderer = new PDFRenderer(expectedDocument);
             addExtraPages(expectedDocument, expectedPdfRenderer, 0, markerColor, true);
         }

--- a/src/main/java/de/redsix/pdfcompare/Utilities.java
+++ b/src/main/java/de/redsix/pdfcompare/Utilities.java
@@ -1,6 +1,7 @@
 package de.redsix.pdfcompare;
 
 import de.redsix.pdfcompare.env.Environment;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -102,7 +103,7 @@ public class Utilities {
     }
 
     private static int getNumberOfPages(final InputStream documentIS, Environment environment) throws IOException {
-        try (PDDocument pdDocument = PDDocument.load(documentIS, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
+        try (PDDocument pdDocument = Loader.loadPDF(documentIS, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
             return pdDocument.getNumberOfPages();
         }
     }
@@ -114,7 +115,7 @@ public class Utilities {
     }
 
     public static ImageWithDimension renderPage(final InputStream documentIS, final int page, Environment environment) throws IOException {
-        try (PDDocument pdDocument = PDDocument.load(documentIS, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
+        try (PDDocument pdDocument = Loader.loadPDF(documentIS, Utilities.getMemorySettings(environment.getDocumentCacheSize()))) {
             if (page >= pdDocument.getNumberOfPages()) {
                 throw new IllegalArgumentException("Page out of range. Last page is: " + pdDocument.getNumberOfPages());
             }

--- a/src/main/java/de/redsix/pdfcompare/ui/Display.java
+++ b/src/main/java/de/redsix/pdfcompare/ui/Display.java
@@ -7,7 +7,7 @@ import de.redsix.pdfcompare.PdfComparator;
 import de.redsix.pdfcompare.cli.CliArguments;
 import de.redsix.pdfcompare.env.DefaultEnvironment;
 import de.redsix.pdfcompare.env.Environment;
-import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 
 import javax.swing.*;
@@ -433,7 +433,7 @@ public class Display {
 
     private static boolean isInvalidPassword(final File file, final String password) throws IOException {
         try {
-            PDDocument.load(file, password).close();
+            Loader.loadPDF(file, password).close();
         } catch (InvalidPasswordException e) {
             return true;
         }


### PR DESCRIPTION
Upgrading the version of pdfbox to 3.0.0-RC1.
This also necessitated some small changes to use the new Loader when creating PDDocuments from InputStreams.