### PR TITLE
Upgrade to PDFBox 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>


### PR DESCRIPTION
The PDFBox 3.0.0 contains some [critical bugs](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310760&version=12353552), most importantly [PDFBOX-5654](https://issues.apache.org/jira/browse/PDFBOX-5654)